### PR TITLE
Include metadata for non-transferred files.

### DIFF
--- a/encode-ingest/src/main/scala/org/broadinstitute/gdr/encode/steps/google/BuildStsManifest.scala
+++ b/encode-ingest/src/main/scala/org/broadinstitute/gdr/encode/steps/google/BuildStsManifest.scala
@@ -7,6 +7,7 @@ import fs2.Stream
 import io.circe.JsonObject
 import org.apache.commons.codec.binary.{Base64, Hex}
 import org.broadinstitute.gdr.encode.steps.IngestStep
+import org.broadinstitute.gdr.encode.steps.transform.JoinReplicatesToFiles
 
 import scala.language.higherKinds
 
@@ -18,6 +19,11 @@ class BuildStsManifest(fileMetadata: File, override protected val out: File)
 
     val manifestRows = IngestStep
       .readJsonArray(fileMetadata)
+      .filter { file =>
+        file(JoinReplicatesToFiles.FileAvailableField)
+          .flatMap(_.asBoolean)
+          .getOrElse(false)
+      }
       .evalMap(buildFileRow[F])
 
     Stream

--- a/encode-ingest/src/main/scala/org/broadinstitute/gdr/encode/steps/transform/JoinReplicatesToFiles.scala
+++ b/encode-ingest/src/main/scala/org/broadinstitute/gdr/encode/steps/transform/JoinReplicatesToFiles.scala
@@ -23,7 +23,6 @@ class JoinReplicatesToFiles(
       .flatMap { replicateTable =>
         IngestStep
           .readJsonArray(extendedFileMetadata)
-          .filter(shouldTransfer)
           .map { fileRecord =>
             for {
               replicateIds <- fileRecord(ShapeFileMetadata.ReplicateLinkField)
@@ -33,7 +32,10 @@ class JoinReplicatesToFiles(
                 replicateIds
               )
             } yield {
-              joinedJson
+              joinedJson.add(
+                JoinReplicatesToFiles.FileAvailableField,
+                shouldTransfer(joinedJson).asJson
+              )
             }
           }
       }
@@ -92,4 +94,6 @@ object JoinReplicatesToFiles {
     "bigBed" -> "peaks",
     "bigWig" -> "fold change over control"
   )
+
+  val FileAvailableField = "gcs_file_available"
 }

--- a/encode-ingest/src/main/wdl/bam_preprocessing/PreprocessEncodeBams.options.json
+++ b/encode-ingest/src/main/wdl/bam_preprocessing/PreprocessEncodeBams.options.json
@@ -2,6 +2,5 @@
   "read_from_cache": true,
   "write_to_cache": true,
   "google_project": "broad-gdr-encode",
-  "jes_gcs_root": "gs://broad-gdr-encode-storage/broad-gdr-encode-caas-execution",
-  "user_service_account_json": ???
+  "jes_gcs_root": "gs://broad-gdr-encode-storage/broad-gdr-encode-caas-execution"
 }


### PR DESCRIPTION
Non-transferred files still appear in the workspace metadata so users can trace file derivations. A new boolean field indicates whether or not each file has been transferred to cloud storage.